### PR TITLE
Set environment option, when `puppet apply`

### DIFF
--- a/lib/pero/puppet.rb
+++ b/lib/pero/puppet.rb
@@ -172,6 +172,7 @@ module Pero
         ret << " --#{n}" if options[n]
       end
       ret << " --tags #{options["tags"].join(",")}" if options["tags"]
+      ret << " --environment #{options["environment"]}" if options["environment"]
       ret
     end
 


### PR DESCRIPTION
I tried `pero apply --environment staging --server-version --server-version 6.13.0`, but pero prints this message.

```
I, [2021-03-16T15:31:40.217415 #1117]  INFO -- : 10.51.96.22:Info: Using configured environment 'production'
I, [2021-03-16T15:31:40.226467 #1117]  INFO -- : 10.51.96.22:Info: Retrieving pluginfacts
```

And, pero was not applied to staging enviroment serves.