### PR TITLE
Add workarounds for legacy Puppet ( < 3.0.0 )

### DIFF
--- a/lib/pero/docker.rb
+++ b/lib/pero/docker.rb
@@ -178,7 +178,12 @@ RUN echo -e "#{puppet_config.split(/\n/).join("\\n")}" > #{conf_dir}/puppet.conf
     end
 
     def run_cmd
-      release_package,package_name, conf_dir  = if Gem::Version.new("5.0.0") > Gem::Version.new(server_version)
+      if Gem::Version.new("3.0.0") > Gem::Version.new(server_version)
+        # /var/puppet/run is created for the first time by running `puppet master`,
+        # but `puppet master` will fail because the permissions are wrong.
+        # So, let the `puppet master` fail once, fix the permission of /var/puppet/run, and execute `puppet master` again.
+        'puppet master --no-daemonize --verbose || (chown puppet: /var/puppet/run && puppet master --no-daemonize --verbose)'
+      elsif Gem::Version.new("5.0.0") > Gem::Version.new(server_version)
         'puppet master --no-daemonize --verbose'
       elsif Gem::Version.new("6.0.0") > Gem::Version.new(server_version)
         'puppetserver foreground'

--- a/lib/pero/docker.rb
+++ b/lib/pero/docker.rb
@@ -161,7 +161,7 @@ RUN echo -e "#{puppet_config.split(/\n/).join("\\n")}" > #{conf_dir}/puppet.conf
     end
 
     def create_ca
-      release_package,package_name, conf_dir  = if Gem::Version.new("5.0.0") > Gem::Version.new(server_version)
+      if Gem::Version.new("5.0.0") > Gem::Version.new(server_version)
         'puppet cert generate `hostname` --dns_alt_names localhost,127.0.0.1'
       elsif Gem::Version.new("6.0.0") > Gem::Version.new(server_version)
         'puppet cert generate `hostname` --dns_alt_names localhost,127.0.0.1'

--- a/lib/pero/docker.rb
+++ b/lib/pero/docker.rb
@@ -149,9 +149,16 @@ RUN sed -i "s|#baseurl=|baseurl=|g" /etc/yum.repos.d/CentOS-Base.repo \
         ''
       end
 
+      legacy_signing = if Gem::Version.new("3.0.0") > Gem::Version.new(server_version)
+        "RUN echo 'LegacySigningMDs md5' >> /etc/pki/tls/legacy-settings"
+      else
+        ''
+      end
+
       <<-EOS
 FROM #{from_image}
 #{vault_repo}
+#{legacy_signing}
 RUN curl -L -k -O https://yum.puppetlabs.com/#{release_package}  && \
 rpm -ivh #{release_package}
 RUN yum install -y #{package_name}-#{server_version}


### PR DESCRIPTION
Add 2 workarounds for legacy Puppet ( < 3.0.0 )

1. Allow legacy signing to support MD5 signing
2. Change permission `/var/puppet/run` to run `puppet master` 
