### PR TITLE
bugfix. return if nodes.empty?

### DIFF
--- a/lib/pero/cli.rb
+++ b/lib/pero/cli.rb
@@ -57,7 +57,10 @@ module Pero
 
       prepare
       nodes = Pero::History.search(name_regexp)
-      return unless nodes
+      if nodes.empty?
+        Pero.log.info 'No matching node found.'
+        return
+      end
       m = Mutex.new
 
       begin


### PR DESCRIPTION
- nodes is not nil.
  - https://github.com/pyama86/pero/blob/3306bd3e3a8c2ffe427dc93ed1efb3389d09cd4e/lib/pero/history.rb?plain=1#L6-L15
- If nodes is an empty array, log that no matching nodes are found.

```ruby
irb(main):001:0> RUBY_VERSION
=> "2.6.8"
irb(main):002:0> nodes = []
=> []
irb(main):003:0> puts 'No matching node found.' unless nodes
=> nil
irb(main):004:0> puts 'No matching node found.' if nodes.empty?
No matching node found.
=> nil
```